### PR TITLE
'add fake tenantcluster for tests'

### DIFF
--- a/tenantclustertest/tenantclustertest.go
+++ b/tenantclustertest/tenantclustertest.go
@@ -1,0 +1,26 @@
+package tenantclustertest
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+)
+
+// Config represents the configuration used to create a new tenant cluster
+// service.
+type Config struct {
+}
+
+// TenantCluster provides functionality for connecting to tenant clusters.
+type TenantClusterTest struct {
+}
+
+// New creates a new tenant cluster service.
+func New(config Config) *TenantClusterTest {
+	t := &TenantClusterTest{}
+	return t
+}
+
+func (t *TenantClusterTest) NewRestConfig(ctx context.Context, clusterID, apiDomain string) (*rest.Config, error) {
+	return nil, nil
+}


### PR DESCRIPTION
need some fake tenantcluster for testing purposes for https://github.com/giantswarm/kvm-operator/pull/826

as the endpoint resource has bunch of tests and they are failing since TenantCluster is nil

But I have no idea what I am doing here.

```
--- FAIL: Test_Resource_Endpoint_ApplyCreateChange (0.00s)
    create_test.go:84: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_newCreateChange (0.00s)
    create_test.go:206: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_GetCurrentState (0.00s)
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/0 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/1 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/2 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/3 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/4 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/5 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_GetCurrentState/6 (0.00s)
        current_test.go:234: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_ApplyDeleteChange (0.00s)
    delete_test.go:136: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_newDeleteChange (0.00s)
    --- FAIL: Test_Resource_Endpoint_newDeleteChange/0 (0.00s)
        delete_test.go:444: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newDeleteChange/1 (0.00s)
        delete_test.go:444: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newDeleteChange/2 (0.00s)
        delete_test.go:444: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newDeleteChange/3 (0.00s)
        delete_test.go:444: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_GetDesiredState (0.00s)
    desired_test.go:128: expected <nil> got endpoint.Config.TenantCluster must not be empty: invalid config error
--- FAIL: Test_Resource_Endpoint_newUpdateChange (0.00s)
    --- FAIL: Test_Resource_Endpoint_newUpdateChange/0 (0.00s)
        update_test.go:309: endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newUpdateChange/1 (0.00s)
        update_test.go:309: endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newUpdateChange/2 (0.00s)
        update_test.go:309: endpoint.Config.TenantCluster must not be empty: invalid config error
    --- FAIL: Test_Resource_Endpoint_newUpdateChange/3 (0.00s)
        update_test.go:309: endpoint.Config.TenantCluster must not be empty: invalid config error
```